### PR TITLE
nvme: nvme_security_receive use nvme_passthru_cmd directly

### DIFF
--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -292,25 +292,10 @@ static int send_rpmb_req(nvme_link_t l, unsigned char tgt, int size,
 	return nvme_security_send(l, &args);
 }
 
-static int recv_rpmb_rsp(nvme_link_t l, int tgt, int size,
-			 struct rpmb_data_frame_t *rsp)
+static int recv_rpmb_rsp(nvme_link_t l, int tgt, int size, struct rpmb_data_frame_t *rsp)
 {
-
-	struct nvme_security_receive_args args = {
-		.args_size	= sizeof(args),
-		.nsid		= 0,
-		.nssf		= tgt,
-		.spsp0		= RPMB_NVME_SPSP,
-		.spsp1		= 0,
-		.secp		= RPMB_NVME_SECP,
-		.al		= 0,
-		.data_len	= size,
-		.data		= (void *)rsp,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= NULL,
-	};
-
-	return nvme_security_receive(l, &args);
+	return nvme_security_receive(l, 0, tgt, RPMB_NVME_SPSP, 0, RPMB_NVME_SECP, 0, (void *)rsp,
+				     size, NULL);
 }
 
 /* Initialize nonce value in rpmb request frame */

--- a/nvme.c
+++ b/nvme.c
@@ -5986,16 +5986,9 @@ static int get_register(int argc, char **argv, struct command *cmd, struct plugi
 
 static int nvme_set_single_property(nvme_link_t l, int offset, uint64_t value)
 {
-	struct nvme_set_property_args args = {
-		.args_size	= sizeof(args),
-		.offset		= offset,
-		.value		= value,
-		.timeout	= nvme_cfg.timeout,
-		.result		= NULL,
-	};
 	int err;
 
-	err = nvme_set_property(l, &args);
+	err = nvme_set_property(l, offset, value, NULL);
 	if (err < 0)
 		nvme_show_error("set-property: %s", nvme_strerror(-err));
 	else if (!err)

--- a/nvme.c
+++ b/nvme.c
@@ -7041,19 +7041,8 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 		}
 	}
 
-	struct nvme_directive_send_args args = {
-		.args_size	= sizeof(args),
-		.nsid		= cfg.namespace_id,
-		.dspec		= cfg.dspec,
-		.doper		= cfg.doper,
-		.dtype		= cfg.dtype,
-		.cdw12		= dw12,
-		.data_len	= cfg.data_len,
-		.data		= buf,
-		.timeout	= nvme_cfg.timeout,
-		.result		= &result,
-	};
-	err = nvme_directive_send(l, &args);
+	err = nvme_directive_send(l, cfg.namespace_id, cfg.doper, cfg.dtype, cfg.dspec, dw12, buf,
+				  cfg.data_len, &result);
 	if (err < 0) {
 		nvme_show_error("dir-send: %s", nvme_strerror(-err));
 		return err;

--- a/nvme.c
+++ b/nvme.c
@@ -4543,13 +4543,11 @@ static int wait_self_test(nvme_link_t l)
 	return 0;
 }
 
-static void abort_self_test(nvme_link_t l, struct nvme_dev_self_test_args *args)
+static void abort_self_test(nvme_link_t l, __u32 nsid)
 {
 	int err;
 
-	args->stc = NVME_DST_STC_ABORT;
-
-	err = nvme_dev_self_test(l, args);
+	err = nvme_dev_self_test(l, nsid, NVME_DST_STC_ABORT, NULL);
 	if (!err)
 		printf("Aborting device self-test operation\n");
 	else if (err > 0)
@@ -4634,14 +4632,7 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 		goto check_abort;
 	}
 
-	struct nvme_dev_self_test_args args = {
-		.args_size	= sizeof(args),
-		.nsid		= cfg.namespace_id,
-		.stc		= cfg.stc,
-		.timeout	= nvme_cfg.timeout,
-		.result		= NULL,
-	};
-	err = nvme_dev_self_test(l, &args);
+	err = nvme_dev_self_test(l, cfg.namespace_id, cfg.stc, NULL);
 	if (!err) {
 		if (cfg.stc == NVME_ST_CODE_ABORT)
 			printf("Aborting device self-test operation\n");
@@ -4662,7 +4653,7 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 
 check_abort:
 	if (err == -EINTR)
-		abort_self_test(l, &args);
+		abort_self_test(l, cfg.namespace_id);
 
 	return err;
 }

--- a/nvme.c
+++ b/nvme.c
@@ -8734,18 +8734,8 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 	if (!buf)
 		return -ENOMEM;
 
-	struct nvme_get_lba_status_args args = {
-		.args_size	= sizeof(args),
-		.nsid		= cfg.namespace_id,
-		.slba		= cfg.slba,
-		.mndw		= cfg.mndw,
-		.rl		= cfg.rl,
-		.atype		= cfg.atype,
-		.lbas		= buf,
-		.timeout	= nvme_cfg.timeout,
-		.result		= NULL,
-	};
-	err = nvme_get_lba_status(l, &args);
+	err = nvme_get_lba_status(l, cfg.namespace_id, cfg.slba, cfg.mndw, cfg.atype, cfg.rl, buf,
+				  NULL);
 	if (!err)
 		nvme_show_lba_status(buf, buf_len, flags);
 	else if (err > 0)

--- a/nvme.c
+++ b/nvme.c
@@ -8654,21 +8654,8 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 			return -ENOMEM;
 	}
 
-	struct nvme_security_receive_args args = {
-		.args_size	= sizeof(args),
-		.nsid		= cfg.namespace_id,
-		.nssf		= cfg.nssf,
-		.spsp0		= cfg.spsp & 0xff,
-		.spsp1		= cfg.spsp >> 8,
-		.secp		= cfg.secp,
-		.al		= cfg.al,
-		.data_len	= cfg.size,
-		.data		= sec_buf,
-		.timeout	= nvme_cfg.timeout,
-		.result		= NULL,
-	};
-
-	err = nvme_security_receive(l, &args);
+	err = nvme_security_receive(l, cfg.namespace_id, cfg.nssf, cfg.spsp & 0xff, cfg.spsp >> 8,
+				    cfg.secp, cfg.al, sec_buf, cfg.size, NULL);
 	if (err < 0) {
 		nvme_show_error("security receive: %s", nvme_strerror(-err));
 	} else if (err != 0) {

--- a/nvme.c
+++ b/nvme.c
@@ -4329,16 +4329,7 @@ static int virtual_mgmt(int argc, char **argv, struct command *cmd, struct plugi
 	if (err)
 		return err;
 
-	struct nvme_virtual_mgmt_args args = {
-		.args_size	= sizeof(args),
-		.act		= cfg.act,
-		.rt		= cfg.rt,
-		.cntlid		= cfg.cntlid,
-		.nr		= cfg.nr,
-		.timeout	= nvme_cfg.timeout,
-		.result		= &result,
-	};
-	err = nvme_virtual_mgmt(l, &args);
+	err = nvme_virtual_mgmt(l, cfg.act, cfg.rt, cfg.cntlid, cfg.nr, &result);
 	if (!err)
 		printf("success, Number of Controller Resources Modified (NRM):%#x\n", result);
 	else if (err > 0)

--- a/nvme.c
+++ b/nvme.c
@@ -8951,7 +8951,7 @@ static int lockdown_cmd(int argc, char **argv, struct command *cmd, struct plugi
 		__u8	ifc;
 		__u8	prhbt;
 		__u8	scp;
-		__u8	uuid;
+		__u8	uidx;
 	};
 
 	struct config cfg = {
@@ -8959,7 +8959,7 @@ static int lockdown_cmd(int argc, char **argv, struct command *cmd, struct plugi
 		.ifc	= 0,
 		.prhbt	= 0,
 		.scp	= 0,
-		.uuid	= 0,
+		.uidx	= 0,
 	};
 
 	NVME_ARGS(opts,
@@ -8967,7 +8967,7 @@ static int lockdown_cmd(int argc, char **argv, struct command *cmd, struct plugi
 		  OPT_BYTE("ifc",	'f', &cfg.ifc,      ifc_desc),
 		  OPT_BYTE("prhbt",	'p', &cfg.prhbt,    prhbt_desc),
 		  OPT_BYTE("scp",	's', &cfg.scp,      scp_desc),
-		  OPT_BYTE("uuid",	'U', &cfg.uuid,     uuid_desc));
+		  OPT_BYTE("uuid",	'U', &cfg.uidx,     uuid_desc));
 
 	err = parse_and_open(&r, &l, argc, argv, desc, opts);
 	if (err)
@@ -8986,22 +8986,12 @@ static int lockdown_cmd(int argc, char **argv, struct command *cmd, struct plugi
 		nvme_show_error("invalid scope settings:%d", cfg.scp);
 		return -1;
 	}
-	if (cfg.uuid > 127) {
-		nvme_show_error("invalid UUID index settings:%d", cfg.uuid);
+	if (cfg.uidx > 127) {
+		nvme_show_error("invalid UUID index settings:%d", cfg.uidx);
 		return -1;
 	}
 
-	struct nvme_lockdown_args args = {
-		.args_size	= sizeof(args),
-		.scp		= cfg.scp,
-		.prhbt		= cfg.prhbt,
-		.ifc		= cfg.ifc,
-		.ofi		= cfg.ofi,
-		.uuidx		= cfg.uuid,
-		.timeout	= nvme_cfg.timeout,
-		.result		= NULL,
-	};
-	err = nvme_lockdown(l, &args);
+	err = nvme_lockdown(l, cfg.scp, cfg.prhbt, cfg.ifc, cfg.ofi, cfg.uidx, NULL);
 	if (err < 0)
 		nvme_show_error("lockdown: %s", nvme_strerror(-err));
 	else if (err > 0)

--- a/nvme.c
+++ b/nvme.c
@@ -5508,19 +5508,8 @@ static int sanitize_cmd(int argc, char **argv, struct command *cmd, struct plugi
 		}
 	}
 
-	struct nvme_sanitize_nvm_args args = {
-		.args_size	= sizeof(args),
-		.sanact		= cfg.sanact,
-		.ause		= cfg.ause,
-		.owpass		= cfg.owpass,
-		.oipbp		= cfg.oipbp,
-		.nodas		= cfg.no_dealloc,
-		.ovrpat		= cfg.ovrpat,
-		.result		= NULL,
-		.emvs		= cfg.emvs,
-	};
-
-	err = nvme_sanitize_nvm(l, &args);
+	err = nvme_sanitize_nvm(l, cfg.sanact, cfg.ause, cfg.owpass, cfg.oipbp, cfg.no_dealloc,
+				cfg.emvs, cfg.ovrpat, NULL);
 	if (err < 0)
 		nvme_show_error("sanitize: %s", nvme_strerror(-err));
 	else if (err > 0)

--- a/nvme.c
+++ b/nvme.c
@@ -8910,19 +8910,8 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 			return -ENOMEM;
 	}
 
-	struct nvme_directive_recv_args args = {
-		.args_size	= sizeof(args),
-		.nsid		= cfg.namespace_id,
-		.dspec		= cfg.dspec,
-		.doper		= cfg.doper,
-		.dtype		= cfg.dtype,
-		.cdw12		= dw12,
-		.data_len	= cfg.data_len,
-		.data		= buf,
-		.timeout	= nvme_cfg.timeout,
-		.result		= &result,
-	};
-	err = nvme_directive_recv(l, &args);
+	err = nvme_directive_recv(l, cfg.namespace_id, cfg.doper, cfg.dtype, cfg.dspec, dw12, buf,
+				  cfg.data_len, &result);
 	if (!err)
 		nvme_directive_show(cfg.dtype, cfg.doper, cfg.dspec, cfg.namespace_id,
 				    result, buf, cfg.data_len, flags);

--- a/nvme.c
+++ b/nvme.c
@@ -8790,16 +8790,7 @@ static int capacity_mgmt(int argc, char **argv, struct command *cmd, struct plug
 		return -1;
 	}
 
-	struct nvme_capacity_mgmt_args args = {
-		.args_size	= sizeof(args),
-		.op		= cfg.operation,
-		.element_id	= cfg.element_id,
-		.cdw11		= cfg.dw11,
-		.cdw12		= cfg.dw12,
-		.timeout	= nvme_cfg.timeout,
-		.result		= &result,
-	};
-	err = nvme_capacity_mgmt(l, &args);
+	err = nvme_capacity_mgmt(l, cfg.operation, cfg.element_id, cfg.dw11, cfg.dw12, &result);
 	if (!err) {
 		printf("Capacity Management Command is Success\n");
 		if (cfg.operation == 1)


### PR DESCRIPTION
Move nvme_security_receive_args to this repository as dropped in libnvme.