### PR TITLE
ioctl: fix nvme_get_log_error call

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1200,7 +1200,7 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 	if (!err_log)
 		return -ENOMEM;
 
-	err = nvme_get_log_error(l, cfg.log_entries, false, err_log);
+	err = nvme_get_log_error(l, false, cfg.log_entries, err_log);
 	if (!err)
 		nvme_show_error_log(err_log, cfg.log_entries,
 				    nvme_link_get_name(l), flags);

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -2189,7 +2189,7 @@ static void GetErrorlogData(nvme_link_t l, int entries, const char *dir)
 	if (!error_log)
 		return;
 
-	if (!nvme_get_log_error(l, entries, false, error_log))
+	if (!nvme_get_log_error(l, false, entries, error_log))
 		WriteData((__u8 *)error_log, logSize, dir,
 			  "error_information_log.bin", "error log");
 

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -10173,7 +10173,7 @@ static int wdc_do_drive_essentials(nvme_root_t r, nvme_link_t l,
 	dataBuffer = calloc(1, elogBufferSize);
 	elogBuffer = (struct nvme_error_log_page *)dataBuffer;
 
-	ret = nvme_get_log_error(l, elogNumEntries, false,
+	ret = nvme_get_log_error(l, false, elogNumEntries,
 				 elogBuffer);
 	if (ret) {
 		fprintf(stderr, "ERROR: WDC: nvme_error_log() failed, ret = %d\n", ret);


### PR DESCRIPTION
Put the function argument in the correct order.

Fixes: e3029af ("nvme: nvme_get_log use nvme_passthru_cmd directly")